### PR TITLE
Pin to Pillow 7.1.2+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email="max.humber@gmail.com",
     license="MIT",
     py_modules=["gif"],
-    install_requires=["matplotlib", "Pillow>=6.0.0,<=7.0.0"],
+    install_requires=["matplotlib", "Pillow>=7.1.2"],
     python_requires=">=3.6",
     setup_requires=["setuptools>=38.6.0"],
 )


### PR DESCRIPTION
Update the pin in https://github.com/maxhumber/gif/pull/2 and https://github.com/maxhumber/gif/commit/c0c8dc30e346caa5f11556175a6c487f8601a7ef.

Pillow 7.1.2 was released yesterday with a fix for https://github.com/python-pillow/Pillow/issues/4518.

Alternatively you could pin something like this:

`Pillow>=6.0.0,!=7.1.0,!=7.1.1`

